### PR TITLE
support multiple instances of plugin on same page

### DIFF
--- a/django_json_widget/templates/django_json_widget.html
+++ b/django_json_widget/templates/django_json_widget.html
@@ -4,17 +4,19 @@
 
 
 <script>
-    var container = document.getElementById("{{ name }}_editor");
-    var options = {
-        modes: ['text', 'code', 'tree', 'form', 'view'],
-        mode: 'tree',
-        search: true,
-        onChange: function () {
-            var json = editor.get();
-            document.getElementById("id_{{ name }}").value=JSON.stringify(json);
-        }
-    };
-    var editor = new JSONEditor(container, options);
-    var json = {{ data|safe }};
-    editor.set(json);
+    (function() {
+        var container = document.getElementById("{{ name }}_editor");
+        var options = {
+            modes: ['text', 'code', 'tree', 'form', 'view'],
+            mode: 'tree',
+            search: true,
+            onChange: function () {
+                var json = editor.get();
+                document.getElementById("id_{{ name }}").value=JSON.stringify(json);
+            }
+        };
+        var editor = new JSONEditor(container, options);
+        var json = {{ data|safe }};
+        editor.set(json);
+    })();
 </script>


### PR DESCRIPTION
this adds a self invoking wrapping function to scope the variables to the local block.
Otherwise if the plugin was included multiple times (because there were multiple JSON-Fields in the form) the second `script` tag’s variables such as `container` would overwrite the ones from the first tag resulting in the same data being submitted for all models.

Fixes #3