### PR TITLE
Added new attribute to support select default rendering mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,25 @@ Add the widget in your admin.py:
             fields.JSONField: {'widget': JSONEditorWidget},
         }
 
+You can also add the widget in your forms.py and choose the default mode:
+
+.. code-block:: python
+    from django import forms
+    from django_json_widget.widgets import JSONEditorWidget
+    from .models import YourModel
+
+
+    class YourForm(forms.ModelForm):
+        class Meta:
+            model = YourModel
+
+            fields = ('jsonfield',)
+
+            widgets = {
+                # choose one mode from ['text', 'code', 'tree', 'form', 'view']
+                'jsonfield': JSONEditorWidget(mode='code')
+            }
+
 JSONEditorWidget widget
 -----------------------
 

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ Add the widget in your admin.py:
 You can also add the widget in your forms.py and choose the default mode:
 
 .. code-block:: python
+
     from django import forms
     from django_json_widget.widgets import JSONEditorWidget
     from .models import YourModel

--- a/django_json_widget/templates/django_json_widget.html
+++ b/django_json_widget/templates/django_json_widget.html
@@ -8,7 +8,7 @@
         var container = document.getElementById("{{ name }}_editor");
         var options = {
             modes: ['text', 'code', 'tree', 'form', 'view'],
-            mode: 'tree',
+            mode: '{{ mode }}',
             search: true,
             onChange: function () {
                 var json = editor.get();

--- a/django_json_widget/widgets.py
+++ b/django_json_widget/widgets.py
@@ -11,7 +11,7 @@ class JSONEditorWidget(forms.Widget):
 
     template_name = 'django_json_widget.html'
 
-    def __init__(self, attrs=None, mode='text'):
+    def __init__(self, attrs=None, mode='code'):
         if not mode in ['text', 'code', 'tree', 'form', 'view']:
             mode = 'code'
         self.mode = mode

--- a/django_json_widget/widgets.py
+++ b/django_json_widget/widgets.py
@@ -7,14 +7,23 @@ from django.conf import settings
 class JSONEditorWidget(forms.Widget):
     class Media:
         css = {'all': (settings.STATIC_URL + 'dist/jsoneditor.min.css',)}
-        js = (settings.STATIC_URL + 'dist/jsoneditor.min.js', )
+        js = (settings.STATIC_URL + 'dist/jsoneditor.min.js',)
 
     template_name = 'django_json_widget.html'
+
+    def __init__(self, attrs=None, mode='text'):
+        if not mode in ['text', 'code', 'tree', 'form', 'view']:
+            mode = 'code'
+        self.mode = mode
+
+        super().__init__(attrs=attrs)
+
 
     def render(self, name, value, attrs=None):
         context = {
             'data': value,
-            'name': name
+            'name': name,
+            'mode': self.mode,
         }
 
         return mark_safe(render_to_string(self.template_name, context))


### PR DESCRIPTION
I've add an attribute to the `JSONEditorWidget`, which allows users to choose the default rendering mode. This also solve the issue #2 .

```python
    from django import forms
    from django_json_widget.widgets import JSONEditorWidget
    from .models import YourModel


    class YourForm(forms.ModelForm):
        class Meta:
            model = YourModel

            fields = ('jsonfield',)

            widgets = {
                # choose one mode from ['text', 'code', 'tree', 'form', 'view']
                'jsonfield': JSONEditorWidget(mode='code')
            }
```