### PR TITLE
fixed for Django 2.1

### DIFF
--- a/django_json_widget/widgets.py
+++ b/django_json_widget/widgets.py
@@ -11,7 +11,7 @@ class JSONEditorWidget(forms.Widget):
 
     template_name = 'django_json_widget.html'
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         context = {
             'data': value,
             'name': name


### PR DESCRIPTION
In Django 2.1, forms.Widget.render has one new parameter called renderer which causes an error in current version. 