### PR TITLE
Fix for the python2.7 compatibility

### DIFF
--- a/django_json_widget/widgets.py
+++ b/django_json_widget/widgets.py
@@ -1,3 +1,4 @@
+from builtins import super
 from django import forms
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'django_json_widget',
     ],
     include_package_data=True,
-    install_requires=[],
+    install_requires=['future'],
     license="MIT",
     zip_safe=False,
     keywords='django-json-widget',


### PR DESCRIPTION
This will solve the python2.7 compatibitly but will add the 'future' dependency.

The other solution is to ser the full `super` syntax.

Regards,