### PR TITLE
Make widget more configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Add the widget in your admin.py:
             fields.JSONField: {'widget': JSONEditorWidget},
         }
 
-You can also add the widget in your forms.py and choose the default mode:
+You can also add the widget in your forms.py:
 
 .. code-block:: python
 
@@ -63,9 +63,23 @@ You can also add the widget in your forms.py and choose the default mode:
             fields = ('jsonfield',)
 
             widgets = {
-                # choose one mode from ['text', 'code', 'tree', 'form', 'view']
-                'jsonfield': JSONEditorWidget(mode='code')
+                'jsonfield': JSONEditorWidget
             }
+
+Configuration
+-------------
+
+You can customize the JSONEditorWidget with the following options:
+
+* **width**: Width of the editor as a string with CSS size units (px, em, % etc). Defaults to ``90%``.
+* **height**: Height of the editor as a string CSS size units. Defaults to ``550px``.
+* **options**: A dict of options accepted by the `JSON editor`_. Options that require functions (eg. onError) are not supported. 
+* **mode (deprecated)**: The default editor mode. This argument is redundant because it can be specified as a part of ``options``.  Preserved for backwards compatibility with version 0.2.0.
+* **attrs**: HTML attributes to be applied to the wrapper element. See the `Django Widget documentation`_.
+
+.. _json editor: https://github.com/josdejong/jsoneditor/blob/master/docs/api.md#configuration-options
+.. _Django Widget documentation: https://docs.djangoproject.com/en/2.1/ref/forms/widgets/#django.forms.Widget.attrs
+
 
 JSONEditorWidget widget
 -----------------------

--- a/django_json_widget/templates/django_json_widget.html
+++ b/django_json_widget/templates/django_json_widget.html
@@ -1,22 +1,20 @@
-<div id="{{ name }}_editor" style="height:500px;float:right;width:90%;"></div>
+<div {% if not widget.attrs.style %}style="height:{{widget.height|default:'500px'}};width:{{widget.width|default:'90%'}};display:inline-block;"{% endif %}{% include "django/forms/widgets/attrs.html" %}></div>
 
-<textarea cols="40" id="id_{{ name }}" name="{{ name }}" rows="10" required="" style="display: none">{{ data }}</textarea>
-
+<textarea id="{{widget.attrs.id}}_textarea" name="{{ widget.name }}" required="" style="display: none">{{ widget.value }}</textarea>
 
 <script>
     (function() {
-        var container = document.getElementById("{{ name }}_editor");
-        var options = {
-            modes: ['text', 'code', 'tree', 'form', 'view'],
-            mode: '{{ mode }}',
-            search: true,
-            onChange: function () {
-                var json = editor.get();
-                document.getElementById("id_{{ name }}").value=JSON.stringify(json);
-            }
-        };
+        var container = document.getElementById("{{ widget.attrs.id }}");
+        var textarea = document.getElementById("{{widget.attrs.id}}_textarea");
+
+        var options = {{ widget.options|safe }};
+        options.onChange = function () {
+            var json = editor.get();
+            textarea.value=JSON.stringify(json);
+        }
+
         var editor = new JSONEditor(container, options);
-        var json = {{ data|safe }};
+        var json = {{ widget.value|safe }};
         editor.set(json);
     })();
 </script>

--- a/django_json_widget/widgets.py
+++ b/django_json_widget/widgets.py
@@ -1,7 +1,7 @@
+import json
 from builtins import super
+
 from django import forms
-from django.template.loader import render_to_string
-from django.utils.safestring import mark_safe
 from django.conf import settings
 
 
@@ -13,19 +13,25 @@ class JSONEditorWidget(forms.Widget):
     template_name = 'django_json_widget.html'
 
 
-    def __init__(self, attrs=None, mode='code'):
-        if not mode in ['text', 'code', 'tree', 'form', 'view']:
-            mode = 'code'
-        self.mode = mode
+    def __init__(self, attrs=None, mode='code', options=None, width=None, height=None):
+        default_options = {
+            'modes': ['text', 'code', 'tree', 'form', 'view'],
+            'mode': mode,
+            'search': True,
+        }
+        if options:
+            default_options.update(options)
+        
+        self.options = default_options
+        self.width = width
+        self.height = height
 
         super().__init__(attrs=attrs)
 
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        context['widget']['options'] = json.dumps(self.options)
+        context['widget']['width'] = self.width
+        context['widget']['height'] = self.height
 
-    def render(self, name, value, attrs=None, renderer=None):
-        context = {
-            'data': value,
-            'name': name,
-            'mode': self.mode,
-        }
-
-        return mark_safe(render_to_string(self.template_name, context))
+        return context

--- a/django_json_widget/widgets.py
+++ b/django_json_widget/widgets.py
@@ -12,7 +12,6 @@ class JSONEditorWidget(forms.Widget):
 
     template_name = 'django_json_widget.html'
 
-
     def __init__(self, attrs=None, mode='code', options=None, width=None, height=None):
         default_options = {
             'modes': ['text', 'code', 'tree', 'form', 'view'],
@@ -21,7 +20,7 @@ class JSONEditorWidget(forms.Widget):
         }
         if options:
             default_options.update(options)
-        
+
         self.options = default_options
         self.width = width
         self.height = height


### PR DESCRIPTION
Make json widget more configurable and consistent with other widgets  …
- Accept Width and height arguments, but default to the old hardcoded
values for backwards compability
- Apply "display: inline-block" style instead of "float: right". This will
wrap the element to the next line instead of overlapping the label if it
ends up too wide. This is consistent with the default behavior of form
elements like textarea which this widget replaces. Addresses #12 
- Apply attrs to the container div to keep behavior consistent with
other standard widgets instead of silently ignoring the attrs argument.
- Allow all jsoneditor options to be configured with the "options"
argument
- The "mode" argument is not strictly needed anymore because the
mode can be as a part of 'options', but still accept it for backwards
compatibility
- Don't override the render method, just override the get_context
because we only need to set a few extra context vars. Keep behavior
consistent with other widgets, and play nicely with other apps like
"django-widget-tewaks"