### PR TITLE
Prevent XSS injection if "</script>" present in data

### DIFF
--- a/django_json_widget/templates/django_json_widget.html
+++ b/django_json_widget/templates/django_json_widget.html
@@ -16,7 +16,7 @@
             }
         };
         var editor = new JSONEditor(container, options);
-        var json = {{ data|safe }};
+        var json = JSON.parse("{{ data|escapejs }}");
         editor.set(json);
     })();
 </script>


### PR DESCRIPTION
There's currently a dangerous XSS injection opportunity if any data includes a string including a closing script tag. It will cause the script to be closed early, and any subsequent characters may be injected into the HTML of the admin page, including malicious scripts. `escapejs` within a string is a better filter to use for this purpose, and we parse the resulting string.

Users may apply a temporary fix in their own codebases with the following:

```
class PatchedJSONEditorWidget(JSONEditorWidget):
  template_name = 'django_json_widget_patched.html'
```

And then replace the offending line in django_json_widget_patched.html in your codebase.