### PR TITLE
Use relative path for media assets

### DIFF
--- a/django_json_widget/widgets.py
+++ b/django_json_widget/widgets.py
@@ -7,8 +7,8 @@ from django.conf import settings
 
 class JSONEditorWidget(forms.Widget):
     class Media:
-        css = {'all': (settings.STATIC_URL + 'dist/jsoneditor.min.css',)}
-        js = (settings.STATIC_URL + 'dist/jsoneditor.min.js',)
+        css = {'all': ('dist/jsoneditor.min.css',)}
+        js = ('dist/jsoneditor.min.js',)
 
     template_name = 'django_json_widget.html'
 


### PR DESCRIPTION
I had a problem with asset URL, and inspected into it.

css and js property of django Media class is rendered by [render_js](https://github.com/django/django/blob/master/django/forms/widgets.py#L80) and [render_css](https://github.com/django/django/blob/master/django/forms/widgets.py#L88) method.

When look into that method, it calls [absolute_path](https://github.com/django/django/blob/master/django/forms/widgets.py#L99) method to make a path absolute, and absolute_path calls [static](https://github.com/django/django/blob/master/django/templatetags/static.py#L162) function, and it calls [StaticNode.handle_simple](https://github.com/django/django/blob/master/django/templatetags/static.py#L115) method.

And, this `handle_simple` method do the same things you do, turn a path to absolute one with `storage.url()`.

So, default django Media logic act like this:

1. If js or css path is an absolute path, use itself.
1. If they are relative one,
   1. If `django.contrib.staticfiles` app is installed, get a `staticfile_storage` which is defined by `settings.STATICFILES_STORAGE` value, and use `storage.url(path)` to convert it to absolute.
   1. If the app is not installed, just add STATIC_URL prefix to the path.

So, I think we can simply to remove any URL prefix and using a relative path would works well.