### PR TITLE
use django's static templatetag to generate static urls

### DIFF
--- a/django_json_widget/widgets.py
+++ b/django_json_widget/widgets.py
@@ -2,13 +2,13 @@ import json
 from builtins import super
 
 from django import forms
-from django.conf import settings
+from django.templatetags.static import static
 
 
 class JSONEditorWidget(forms.Widget):
     class Media:
-        css = {'all': (settings.STATIC_URL + 'dist/jsoneditor.min.css',)}
-        js = (settings.STATIC_URL + 'dist/jsoneditor.min.js',)
+        css = {'all': (static('dist/jsoneditor.min.css'), )}
+        js = (static('dist/jsoneditor.min.js'),)
 
     template_name = 'django_json_widget.html'
 


### PR DESCRIPTION
Hi,

I'm using the `django-storages` package to serve my static files on Digital Ocean and these static urls don't work for me.

I proposed a solution that uses django's internal mehod of fetching static urls.

Let me know if you need anything else from me.

Fixes https://github.com/jmrivas86/django-json-widget/issues/7

