### PR TITLE
Added functionality to override version of JSONEditor to use

### DIFF
--- a/django_json_widget/widgets.py
+++ b/django_json_widget/widgets.py
@@ -2,12 +2,19 @@ import json
 from builtins import super
 
 from django import forms
+from django.conf import settings
 
 
 class JSONEditorWidget(forms.Widget):
     class Media:
-        css = {'all': ('dist/jsoneditor.min.css', )}
-        js = ('dist/jsoneditor.min.js',)
+        js = (
+            getattr(settings, "JSON_EDITOR_JS", 'dist/jsoneditor.js'),
+        )
+        css = {
+            'all': (
+                getattr(settings, "JSON_EDITOR_CSS", 'dist/jsoneditor.css'),
+            )
+        }
 
     template_name = 'django_json_widget.html'
 

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -126,3 +126,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
+
+JSON_EDITOR_JS = 'https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/9.0.3/jsoneditor.js'
+JSON_EDITOR_CSS = 'https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/9.0.3/jsoneditor.css'


### PR DESCRIPTION
Hi, 
Can this PR be merged into master? I'ver made a small change so that it is possible to override/update or source from a cdn the version of jsoneditor used in django-json-widget.

Many thanks,
Ling 
