### PR TITLE
Update README to use models not forms for formfield_overrides

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Add the widget in your admin.py:
 .. code-block:: python
 
     from django.contrib import admin
-    from django.contrib.postgres import fields
+    from django.db import models
     from django_json_widget.widgets import JSONEditorWidget
     from .models import YourModel
 
@@ -44,7 +44,7 @@ Add the widget in your admin.py:
     @admin.register(YourModel)
     class YourModelAdmin(admin.ModelAdmin):
         formfield_overrides = {
-            fields.JSONField: {'widget': JSONEditorWidget},
+            models.JSONField: {'widget': JSONEditorWidget},
         }
 
 You can also add the widget in your forms.py:


### PR DESCRIPTION
I just implemented the library and `forms.JsonField` did not work. From [here](https://stackoverflow.com/a/33954320), I tried `models.` and it worked.