### PR TITLE
Avoid HTML injection via unsafe JSON injection

### DIFF
--- a/django_json_widget/templates/django_json_widget.html
+++ b/django_json_widget/templates/django_json_widget.html
@@ -2,6 +2,10 @@
 
 <textarea id="{{widget.attrs.id}}_textarea" name="{{ widget.name }}" required="" style="display: none">{{ widget.value }}</textarea>
 
+{% with script_id=widget.name|add:"_data" %}
+{{ widget.value|json_script:script_id }}
+{% endwith %}
+
 <script>
     (function() {
         var container = document.getElementById("{{ widget.attrs.id }}");
@@ -14,7 +18,7 @@
         }
 
         var editor = new JSONEditor(container, options);
-        var json = {{ widget.value|safe }};
+        var json = JSON.parse(document.getElementById("{{ widget.name }}_data").textContent);
         editor.set(json);
     })();
 </script>

--- a/django_json_widget/templates/django_json_widget.html
+++ b/django_json_widget/templates/django_json_widget.html
@@ -1,6 +1,6 @@
 <div {% if not widget.attrs.style %}style="height:{{widget.height|default:'500px'}};width:{{widget.width|default:'90%'}};display:inline-block;"{% endif %}{% include "django/forms/widgets/attrs.html" %}></div>
 
-<textarea id="{{widget.attrs.id}}_textarea" name="{{ widget.name }}" required="" style="display: none">{{ widget.value }}</textarea>
+<textarea id="{{widget.attrs.id}}_textarea" name="{{ widget.name }}" required="" style="display: none"></textarea>
 
 {% with script_id=widget.name|add:"_data" %}
 {{ widget.value|json_script:script_id }}
@@ -14,11 +14,12 @@
         var options = {{ widget.options|safe }};
         options.onChange = function () {
             var json = editor.get();
-            textarea.value=JSON.stringify(json);
+            textarea.value = JSON.stringify(json);
         }
 
         var editor = new JSONEditor(container, options);
-        var json = JSON.parse(document.getElementById("{{ widget.name }}_data").textContent);
-        editor.set(json);
+        var content = document.getElementById("{{ widget.name }}_data").textContent;
+        textarea.value = content;
+        editor.set(JSON.parse(content));
     })();
 </script>

--- a/django_json_widget/widgets.py
+++ b/django_json_widget/widgets.py
@@ -40,3 +40,6 @@ class JSONEditorWidget(forms.Widget):
         context['widget']['height'] = self.height
 
         return context
+
+    def format_value(self, value):
+        return json.loads(value)


### PR DESCRIPTION
This change follows the Django docs' suggested approach for safely setting a JSON literal in a template: https://docs.djangoproject.com/en/3.2/ref/templates/builtins/#json-script.

In the old code, if a string literal within the JSON included '</script>', then that would be interpreted by the browser as closing the script tag, and thus allow arbitrary HTML to then be injected into the page. This is especially dangerous if the JSON for the widget can include user content, and if the widget is being used within the Django admin interface.

---

Users who would like to patch this locally, before this fix is merged/released can follow the approach in #21 and derive a patched widget like so:

```
class PatchedJSONEditorWidget(JSONEditorWidget):
    template_name = 'django_json_widget_patched.html'

    def format_value(self, value):
        return json.loads(value)
```

And copy `django_json_widget/templates/django_json_widget.html` from this branch to `templates/django_json_widget_patched.html` in their own app.

---

Fixes jmrivas86/django-json-widget#62.

Note that to merge this safely, we'd need to drop support for at least Django < 2.1, which has been out of extended support since April 2019. 2.2 LTS also goes out of extended support in April; I wonder if it would be worthwhile to align with Django's supported versions, to simplify fixing bugs like this. I've proposed a change in #65 to stop declaring support for < 2.2, which ideally would merge before/with this change.