### PR TITLE
add check for None if value is None

### DIFF
--- a/django_json_widget/widgets.py
+++ b/django_json_widget/widgets.py
@@ -42,4 +42,4 @@ class JSONEditorWidget(forms.Widget):
         return context
 
     def format_value(self, value):
-        return json.loads(value)
+        return None if value is None else json.loads(value)


### PR DESCRIPTION
I got some issues during tests where the value  in the method "format_value" was returned as None. A None value can't be parsed by Pythons json-module so it raised an exception during template generation which crashed my application and test.

Looking at the newest [documentation for format_value](https://github.com/django/django/blob/stable/5.1.x/django/forms/widgets.py#L254) it states that the value is not guaranteed to be valid. The [original implementation](https://github.com/django/django/blob/stable/5.1.x/django/forms/widgets.py#L254) is also more robust.

I just added a quick check, if the value is None, return None. Else try to parse the value with JSON. A slightly better option would be to use try/except and return None in case of failures, but not sure how you prefer it.