### PR TITLE
Add HTML escaping and unescaping for JSON widget values

### DIFF
--- a/django_json_widget/widgets.py
+++ b/django_json_widget/widgets.py
@@ -1,3 +1,4 @@
+import html
 import json
 from builtins import super
 
@@ -39,7 +40,49 @@ class JSONEditorWidget(forms.Widget):
         context['widget']['width'] = self.width
         context['widget']['height'] = self.height
 
+        if value:
+            if isinstance(value, str):
+                try:
+                    value = json.loads(value)
+                except json.JSONDecodeError:
+                    pass
+
+            def escape_html_in_json(obj):
+                if isinstance(obj, str):
+                    return html.escape(obj)
+                elif isinstance(obj, dict):
+                    return {k: escape_html_in_json(v) for k, v in obj.items()}
+                elif isinstance(obj, (list, tuple)):
+                    return [escape_html_in_json(item) for item in obj]
+                return obj
+
+            # Escape HTML in the value
+            safe_value = escape_html_in_json(value)
+            # Convert back to JSON string
+            context["widget"]["value"] = json.dumps(safe_value)
+
         return context
 
     def format_value(self, value):
-        return json.loads(value)
+        """
+        When form is submitted, unescape the HTML entities in the JSON data
+        """
+        value = json.loads(value)
+        if value:
+            try:
+                json_value = json.loads(value)
+
+                def unescape_html_in_json(obj):
+                    if isinstance(obj, str):
+                        return html.unescape(obj)
+                    elif isinstance(obj, dict):
+                        return {k: unescape_html_in_json(v) for k, v in obj.items()}
+                    elif isinstance(obj, (list, tuple)):
+                        return [unescape_html_in_json(item) for item in obj]
+                    return obj
+
+                unescaped_value = unescape_html_in_json(json_value)
+                return json.dumps(unescaped_value)
+            except json.JSONDecodeError:
+                return value
+        return value


### PR DESCRIPTION
Issue: #80

Changes:
- Before displaying data, escape HTML codes in the `get_context` method.
- After submitting the form, unescape HTML codes in the `value_from_datadict` method.