### PR TITLE
Fix django extensions

### DIFF
--- a/django_json_widget/widgets.py
+++ b/django_json_widget/widgets.py
@@ -1,5 +1,4 @@
 import json
-from builtins import super
 
 from django import forms
 from django.conf import settings
@@ -31,7 +30,7 @@ class JSONEditorWidget(forms.Widget):
         self.width = width
         self.height = height
 
-        super(JSONEditorWidget, self).__init__(attrs=attrs)
+        super().__init__(attrs=attrs)
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
@@ -42,4 +41,7 @@ class JSONEditorWidget(forms.Widget):
         return context
 
     def format_value(self, value):
-        return json.loads(value)
+        if not isinstance(value, (dict, list)):
+            return json.loads(value)
+        else:
+            return value

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -163,6 +163,14 @@ class JSONEditorWidgetValueFormattingTests(TestCase):
         with self.assertRaises((TypeError, json.JSONDecodeError)):
             widget.format_value(None)
 
+    def test_format_value_dict(self):
+        widget = JSONEditorWidget()
+        self.assertEqual(widget.format_value({}), {})
+
+    def test_format_value_list(self):
+        widget = JSONEditorWidget()
+        self.assertEqual(widget.format_value([]), [])
+
 
 class JSONEditorWidgetTemplateRenderingTests(TestCase):
     """Test widget template rendering"""


### PR DESCRIPTION
Using https://github.com/django-extensions/django-extensions `JSONField` we get a dict object in there already so no need to json.load it.